### PR TITLE
Make the whole sender processor a noop

### DIFF
--- a/cmd/relay/app/builder/builder_options.go
+++ b/cmd/relay/app/builder/builder_options.go
@@ -12,6 +12,8 @@ type SenderType string
 const (
 	// ThriftTChannelSenderType represents a thrift-format tchannel-transport sender
 	ThriftTChannelSenderType SenderType = "thrift-tchannel"
+	// ThriftTChannelNullSenderType represents a thrift-format tchannel-transport sender
+	ThriftTChannelNullSenderType SenderType = "thrift-tchannel-null"
 	// ThriftHTTPSenderType represents a thrift-format http-transport sender
 	ThriftHTTPSenderType = "thrift-http"
 	// InvalidSenderType represents an invalid sender


### PR DESCRIPTION
This one makes the whole sender processor a do nothing, so no enqueue and related metrics, OTOH the change is much smaller. As the other one not to be merged.